### PR TITLE
Xfem branch

### DIFF
--- a/framework/include/XFEM/EFAelement2D.h
+++ b/framework/include/XFEM/EFAelement2D.h
@@ -113,6 +113,7 @@ public:
                     std::map< unsigned int, EFAnode*> &EmbeddedNodes, bool add_to_neighbor);
   void add_frag_edge_cut(unsigned int frag_edge_id, double position,
                          std::map< unsigned int, EFAnode*> &EmbeddedNodes);
+  std::vector<EFAfragment2D*> branching_split(std::map<unsigned int, EFAnode*> &EmbeddedNodes);
 
 private:
 

--- a/framework/include/XFEM/EFAelement2D.h
+++ b/framework/include/XFEM/EFAelement2D.h
@@ -88,6 +88,7 @@ public:
   std::set<EFAnode*> get_edge_nodes(unsigned int edge_id) const;
   bool getEdgeNodeParaCoor(EFAnode* node, std::vector<double> &para_coor) const;
   FaceNode* get_interior_node(unsigned int interior_node_id) const;
+  void delete_interior_nodes();
 
   unsigned int num_edges() const;
   void set_edge(unsigned int edge_id, EFAedge* edge);

--- a/framework/include/XFEM/EFAfragment.h
+++ b/framework/include/XFEM/EFAfragment.h
@@ -29,6 +29,7 @@ public:
   virtual unsigned int get_num_cuts() const = 0;
   virtual std::set<EFAnode*> get_all_nodes() const = 0;
   virtual bool isConnected(EFAfragment *other_fragment) const = 0;
+  virtual void remove_invalid_embedded(std::map<unsigned int, EFAnode*> &EmbeddedNodes) = 0;
 
   // common methods
   std::vector<EFAnode*> get_common_nodes(EFAfragment* other) const;

--- a/framework/include/XFEM/EFAfragment2D.h
+++ b/framework/include/XFEM/EFAfragment2D.h
@@ -44,6 +44,7 @@ public:
   virtual unsigned int get_num_cuts() const;
   virtual std::set<EFAnode*> get_all_nodes() const;
   virtual bool isConnected(EFAfragment *other_fragment) const;
+  virtual void remove_invalid_embedded(std::map<unsigned int, EFAnode*> &EmbeddedNodes);
 
   // EFAfragment2D specific methods
   void combine_tip_edges();

--- a/framework/include/XFEM/EFAfragment3D.h
+++ b/framework/include/XFEM/EFAfragment3D.h
@@ -42,6 +42,7 @@ public:
   virtual unsigned int get_num_cuts() const;
   virtual std::set<EFAnode*> get_all_nodes() const;
   virtual bool isConnected(EFAfragment *other_fragment) const;
+  virtual void remove_invalid_embedded(std::map<unsigned int, EFAnode*> &EmbeddedNodes);
 
   // EFAfragment3D specific methods
   void combine_tip_faces();
@@ -57,7 +58,6 @@ public:
   std::vector<EFAfragment3D*> split();
   void create_adjacent_face_ix();
   EFAface* get_adjacent_face(unsigned int face_id, unsigned int edge_id) const;
-  void remove_invalid_embedded(std::map<unsigned int, EFAnode*> &EmbeddedNodes);
   void remove_embedded_node(EFAnode* emb_node);
   bool hasFaceWithOneCut() const;
   void get_node_info(std::vector<std::vector<unsigned int> > &face_node_ix,

--- a/framework/include/XFEM/FaceNode.h
+++ b/framework/include/XFEM/FaceNode.h
@@ -19,20 +19,20 @@
 
 class FaceNode
 {
-  public:
+public:
 
   FaceNode(EFAnode* node, double xi, double eta);
   FaceNode(const FaceNode & other_face_node);
 
   ~FaceNode();
 
-  private:
+private:
 
   EFAnode * _node;
   double _xi;
   double _eta;
 
-  public:
+public:
 
   EFAnode * get_node();
   double get_para_coords(unsigned int i);

--- a/framework/include/XFEM/XFEM.h
+++ b/framework/include/XFEM/XFEM.h
@@ -79,7 +79,7 @@ public:
                                  Point edge_p1, Point edge_p2, Real & dist);
   bool cut_mesh_with_efa();
   Point get_efa_node_coor(EFAnode* CEMnode, EFAelement* CEMElem,
-                          const Elem *elem, MeshBase* displaced_mesh = NULL);
+                          const Elem *elem, MeshBase* displaced_mesh = NULL) const;
 
   /**
    * Get the volume fraction of an element that is physical
@@ -96,6 +96,14 @@ public:
 
   bool is_elem_at_crack_tip(const Elem* elem) const;
   bool is_elem_cut(const Elem* elem) const;
+  void get_frag_faces(const Elem* elem, std::vector<std::vector<Point> > &frag_faces) const;
+
+private:
+
+  void get_frag_edges(const Elem* elem, EFAelement2D* CEMElem,
+                      std::vector<std::vector<Point> > &frag_edges) const;
+  void get_frag_faces(const Elem* elem, EFAelement3D* CEMElem,
+                      std::vector<std::vector<Point> > &frag_faces) const;
 
 private:
   std::vector<MaterialData *> & _material_data;

--- a/framework/include/XFEM/XFEMCutElem.h
+++ b/framework/include/XFEM/XFEMCutElem.h
@@ -58,6 +58,7 @@ public:
   Real get_mf_weights(unsigned int i_qp) const; // ZZY
   virtual Point get_origin(unsigned int plane_id, MeshBase* displaced_mesh=NULL) const = 0;
   virtual Point get_normal(unsigned int plane_id, MeshBase* displaced_mesh=NULL) const = 0;
+  virtual void get_frag_faces(std::vector<std::vector<Point> > &frag_faces, MeshBase* displaced_mesh=NULL) const = 0;
   virtual const EFAelement * get_efa_elem() const = 0;
   virtual unsigned int num_cut_planes() const = 0;
 };

--- a/framework/include/XFEM/XFEMCutElem2D.h
+++ b/framework/include/XFEM/XFEMCutElem2D.h
@@ -37,6 +37,7 @@ public:
   virtual void calc_mf_weights();
   virtual Point get_origin(unsigned int plane_id, MeshBase* displaced_mesh=NULL) const;
   virtual Point get_normal(unsigned int plane_id, MeshBase* displaced_mesh=NULL) const;
+  virtual void get_frag_faces(std::vector<std::vector<Point> > &frag_faces, MeshBase* displaced_mesh=NULL) const;
   virtual const EFAelement * get_efa_elem() const;
   virtual unsigned int num_cut_planes() const;
 

--- a/framework/include/XFEM/XFEMCutElem3D.h
+++ b/framework/include/XFEM/XFEMCutElem3D.h
@@ -35,6 +35,7 @@ public:
   virtual void calc_mf_weights();
   virtual Point get_origin(unsigned int plane_id, MeshBase* displaced_mesh=NULL) const;
   virtual Point get_normal(unsigned int plane_id, MeshBase* displaced_mesh=NULL) const;
+  virtual void get_frag_faces(std::vector<std::vector<Point> > &frag_faces, MeshBase* displaced_mesh=NULL) const;
   virtual const EFAelement * get_efa_elem() const;
   virtual unsigned int num_cut_planes() const;
 

--- a/framework/src/XFEM/EFAelement2D.C
+++ b/framework/src/XFEM/EFAelement2D.C
@@ -699,23 +699,8 @@ EFAelement2D::update_fragments(const std::set<EFAelement*> &CrackTipElements,
 
   // if a fragment only has 1 intersection which is in an interior edge
   // remove this embedded node (MUST DO THIS AFTER combine_tip_edges())
-  if (_fragments.size() == 1 && _fragments[0]->get_num_cuts() == 1)
-  {
-    for (unsigned int i = 0; i < _fragments[0]->num_edges(); ++i)
-    {
-      if (_fragments[0]->is_edge_interior(i) &&
-          _fragments[0]->get_edge(i)->has_intersection())
-      {
-        if (_interior_nodes.size() != 1)
-          mooseError("The element must have 1 interior node at this point");
-        deleteFromMap(EmbeddedNodes,_fragments[0]->get_edge(i)->get_embedded_node(0));
-        _fragments[0]->get_edge(i)->remove_embedded_node(); // set pointer to NULL
-        delete _interior_nodes[0];
-        _interior_nodes.clear();
-        break;
-      }
-    } // i
-  }
+  if (_fragments.size() == 1)
+    _fragments[0]->remove_invalid_embedded(EmbeddedNodes);
 
   // for an element with no fragment, create one fragment identical to the element
   if (_fragments.size() == 0)
@@ -1187,6 +1172,14 @@ EFAelement2D::get_interior_node(unsigned int interior_node_id) const
     return _interior_nodes[interior_node_id];
   else
     mooseError("interior_node_id out of bounds");
+}
+
+void
+EFAelement2D::delete_interior_nodes()
+{
+  for (unsigned int i = 0; i < _interior_nodes.size(); ++i)
+    delete _interior_nodes[i];
+  _interior_nodes.clear();
 }
 
 unsigned int

--- a/framework/src/XFEM/EFAfragment2D.C
+++ b/framework/src/XFEM/EFAfragment2D.C
@@ -369,7 +369,7 @@ EFAfragment2D::split()
           {
             second_node_on_edge = _boundary_edges[iedge]->get_node(0);
             if (!_boundary_edges[inextedge]->containsNode(second_node_on_edge))
-              mooseError("Previous edge does not contain either of the nodes in this edge");
+              mooseError("Next edge does not contain either of the nodes in this edge");
           }
           new_frag->add_edge(new EFAedge(embedded_node2, second_node_on_edge));
         }

--- a/framework/src/XFEM/XFEMCutElem2D.C
+++ b/framework/src/XFEM/XFEMCutElem2D.C
@@ -156,6 +156,19 @@ XFEMCutElem2D::get_normal(unsigned int plane_id, MeshBase* displaced_mesh) const
   return normal;
 }
 
+void
+XFEMCutElem2D::get_frag_faces(std::vector<std::vector<Point> > &frag_faces, MeshBase* displaced_mesh) const
+{
+  frag_faces.clear();
+  for (unsigned int i = 0; i < _efa_elem2d.get_fragment(0)->num_edges(); ++i)
+  {
+    std::vector<Point> edge_points(2, Point(0.0,0.0,0.0));
+    edge_points[0] = get_node_coords(_efa_elem2d.get_frag_edge(0,i)->get_node(0), displaced_mesh);
+    edge_points[1] = get_node_coords(_efa_elem2d.get_frag_edge(0,i)->get_node(1), displaced_mesh);
+    frag_faces.push_back(edge_points);
+  }
+}
+
 const EFAelement*
 XFEMCutElem2D::get_efa_elem() const
 {

--- a/framework/src/XFEM/XFEMCutElem3D.C
+++ b/framework/src/XFEM/XFEMCutElem3D.C
@@ -185,6 +185,13 @@ XFEMCutElem3D::get_normal(unsigned int plane_id, MeshBase* displaced_mesh) const
   return normal;
 }
 
+void
+XFEMCutElem3D::get_frag_faces(std::vector<std::vector<Point> > &frag_faces, MeshBase* displaced_mesh) const
+{
+  // TODO: need to finish this in the future
+  mooseError("not available for XFEMCutElem3D for now");
+}
+
 const EFAelement*
 XFEMCutElem3D::get_efa_elem() const
 {

--- a/unit/include/CutElemMeshTest.h
+++ b/unit/include/CutElemMeshTest.h
@@ -35,6 +35,7 @@ class CutElemMeshTest : public CppUnit::TestFixture
   CPPUNIT_TEST( CutElemMeshTest4 );
   CPPUNIT_TEST( CutElemMeshTest5a );
   CPPUNIT_TEST( CutElemMeshTest5b );
+  CPPUNIT_TEST( CutElemMeshTest5c );
   CPPUNIT_TEST( CutElemMeshTest6a );
   CPPUNIT_TEST( CutElemMeshTest6b );
 
@@ -61,6 +62,7 @@ public:
   void case5Mesh(ElementFragmentAlgorithm &MyMesh);
   void CutElemMeshTest5a();
   void CutElemMeshTest5b();
+  void CutElemMeshTest5c();
 
   void case6Mesh(ElementFragmentAlgorithm &MyMesh);
   void CutElemMeshTest6a();

--- a/unit/src/CutElemMeshTest.C
+++ b/unit/src/CutElemMeshTest.C
@@ -541,9 +541,42 @@ void CutElemMeshTest::CutElemMeshTest5b()
   MyMesh.printMesh();
 }
 
+void CutElemMeshTest::CutElemMeshTest5c()
+{
+  // 0 ----- 1 ----- 2 ----- 3
+  // |       |       |       |
+  // x ----- x --x-- x ----- x
+  // |       |   |   |       |
+  // 4 ----- 5 --x-- 6 ----- 7
+  // |       |   |   |       |
+  // |       |   |   |       |
+  // |       |   |   |       |
+  // 8 ----- 9 --x--10 -----11
+
+  ElementFragmentAlgorithm MyMesh;
+  case5Mesh(MyMesh);
+
+  // add the horizontal cut
+  std::cout<<"\n ***** Running case 5c *****"<<std::endl;
+  MyMesh.addElemEdgeIntersection((unsigned int) 0,0,0.5);
+  MyMesh.addElemEdgeIntersection((unsigned int) 0,2,0.5);
+  MyMesh.addElemEdgeIntersection((unsigned int) 1,1,0.5);
+  MyMesh.addElemEdgeIntersection((unsigned int) 1,2,0.5);
+  MyMesh.addElemEdgeIntersection((unsigned int) 2,2,0.5);
+  MyMesh.addElemEdgeIntersection((unsigned int) 4,1,0.5);
+
+  MyMesh.updatePhysicalLinksAndFragments();
+  MyMesh.updateTopology();
+  MyMesh.clearAncestry();
+  MyMesh.updateEdgeNeighbors();
+  MyMesh.initCrackTipTopology();
+  MyMesh.printMesh();
+}
+
 void
 CutElemMeshTest::case6Mesh(ElementFragmentAlgorithm &MyMesh)
 {
+  // 3D test
   unsigned int q1[] = {0,1,4,3,9,10,13,12};
   std::vector<unsigned int> v1 (q1, q1 + sizeof(q1) / sizeof(unsigned int) );
   MyMesh.add3DElement(v1, 0);


### PR DESCRIPTION
A new commit was just added. The two private methods get_frag_edges and get_frag_faces are just for code clean-up. Another version of get_frag_faces might be useful for the medial axis work. Specifically, the medial axis might intersect with a PF isocontour segment in some tricky cases, which means part of that isocontour segment will lie in the non-physical domain of the partial element after mesh cutting. In such a case, we need the fragment information to truncate the isocontour segment.
